### PR TITLE
Fix missing fsck support for exFAT devices

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -276,6 +276,15 @@ PRODUCT_PACKAGES += \
     init.qcom.post_boot.sh \
     ueventd.qcom.rc
 
+# AOSP filesystems
+PRODUCT_PACKAGES += \
+    fsck.exfat \
+    fsck.ntfs \
+    mke2fs \
+    mkfs.exfat \
+    mkfs.ntfs \
+    mount.ntfs
+
 # Screen density
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi


### PR DESCRIPTION
This pull request aims at fixing the missing support for fsck on exFAT SD cards (or any other external device).

Also, it introduces a couple of the following important packages that aren't compiled by default:

Terminal
WallpaperPicker

NTFS utilities are also bundled.